### PR TITLE
use doubles for startTime and endTime

### DIFF
--- a/src/cpu_profile.cc
+++ b/src/cpu_profile.cc
@@ -82,8 +82,8 @@ namespace nodex {
     profile->Set(NanNew<String>("head"),      head);
 
 #if (NODE_MODULE_VERSION > 0x000B)
-    Local<Value> start_time = NanNew<Number>(node->GetStartTime()/1000000);
-    Local<Value> end_time = NanNew<Number>(node->GetEndTime()/1000000);
+    Local<Value> start_time = NanNew<Number>((double)node->GetStartTime()/1000000.00);
+    Local<Value> end_time = NanNew<Number>((double)node->GetEndTime()/1000000.00);
     Local<Array> samples = NanNew<Array>();
     
     uint32_t count = node->GetSamplesCount();

--- a/test/cpu_cprofiler.js
+++ b/test/cpu_cprofiler.js
@@ -67,6 +67,16 @@ describe('CPU', function() {
       expect(profile.samples.length > 0).to.equal(true);
     });
 
+    it('should record startTime and endTime with subsecond precision', function(done) {
+      profiler.startProfiling('P');
+      var delayInMilliseconds = 150;
+      setTimeout(function() {
+        var profile = profiler.stopProfiling();
+        var elapsedTime = profile.endTime - profile.startTime;
+        expect(elapsedTime).to.be.at.least(delayInMilliseconds / 1000);
+        done();
+      }, delayInMilliseconds);
+    });
   });
 
   describe('Profile', function() {

--- a/v8-profiler.js
+++ b/v8-profiler.js
@@ -111,13 +111,13 @@ var profiler = {
   get profiles() { return binding.cpu.profiles; },
   
   startProfiling: function(name, recsamples) {
-    startTime = Date.now();
+    startTime = Date.now() / 1000;
     binding.cpu.startProfiling(name, recsamples);
   },
   
   stopProfiling: function(name) {
     var profile = binding.cpu.stopProfiling(name);
-    endTime = Date.now();
+    endTime = Date.now() / 1000;
     profile.__proto__ = CpuProfile.prototype;
     if (!profile.startTime) profile.startTime = startTime;
     if (!profile.endTime) profile.endTime = endTime;


### PR DESCRIPTION
don’t lose precision by doing integer arithmetic